### PR TITLE
Set a higher ulimit to avoid capistrano issue

### DIFF
--- a/mac
+++ b/mac
@@ -193,7 +193,6 @@ if ! grep -Fqs "$cmd" "$profile"; then
   printf "\n$cmd\n" >> "$profile"
   print_done
 fi
-<<<<<<< HEAD
 
 # Set a higher ulimit to avoid
 # capistrano issues deploying to many servers
@@ -202,8 +201,6 @@ if [ $LIMIT -gt `ulimit -n` ]; then
    ulimit -n $LIMIT
 fi
 EOF
-=======
->>>>>>> master
 
 # Use osxkeychain for git https passwords
 git config --global credential.helper osxkeychain

--- a/mac
+++ b/mac
@@ -129,6 +129,13 @@ eval "$(rbenv init -)"
 if [[ ! "$PATH" =~ "/usr/local/bin" ]]; then
   export PATH="/usr/local/bin:$PATH"
 fi
+
+# Set a higher ulimit to avoid
+# capistrano issues deploying to many servers
+LIMIT=2048
+if [ $LIMIT -gt `ulimit -n` ]; then
+   ulimit -n $LIMIT
+fi
 EOF
 
 

--- a/mac
+++ b/mac
@@ -197,7 +197,7 @@ fi
 # Set a higher ulimit to avoid
 # capistrano issues deploying to many servers
 LIMIT=2048
-if [ $LIMIT -gt `ulimit -n` ]; then
+if [ $LIMIT -gt "$(ulimit -n)" ]; then
    ulimit -n $LIMIT
 fi
 EOF


### PR DESCRIPTION
_What?_
Sometimes Capistrano likes to yell at you and prevent you from deploying if your ulimit is too low

_How?_
We check to make sure your ulimit is at least 2048 and if it's less than that, we reset it to 2048
