### PR TITLE
Source ~/.bashrc from ~/.bash_profile

### DIFF
--- a/mac
+++ b/mac
@@ -206,6 +206,11 @@ cmd='if [ -e ~/.ksr.rc ]; then source ~/.ksr.rc; fi # Provisioned by ksr laptop 
 case $(basename "$SHELL") in
   bash )
     profile="$HOME/.bashrc"
+
+    # Source bashrc from bash_profile
+    if ! grep -Fqs 'source ~/.bashrc' "$HOME/.bash_profile"; then
+      echo 'source ~/.bashrc' >> "$HOME/.bash_profile"
+    fi
     ;;
   zsh )
     profile="$HOME/.zshrc"


### PR DESCRIPTION
Oh, the joys of multiple config files.

This fixes a gotcha for new installs missing a ~/.bash_profile.

Login shells don’t load ~/.bashrc by default, so we’ll make it happen.

I think we want to continue using ~/.bashrc b/c background processes
could use it.

:wave: @rapoulson 
