### PR TITLE
Allow homebrew ruby

### DIFF
--- a/mac
+++ b/mac
@@ -126,7 +126,6 @@ EOF
 
 ##Uninstall problematic brew packages
 brew uninstall --force brew-cask 2> /dev/null
-brew uninstall --force ruby 2> /dev/null
 brew uninstall --force node 2> /dev/null
 brew uninstall --force node4-lts 2> /dev/null
 


### PR DESCRIPTION
## What

Uninstalling ruby is a gotcha b/c the popular vim Formula depends
on it. If you installed vim recently with `brew install vim`, then ran
this script, it would break your vim installation:

```
$ vim
dyld: Library not loaded: /usr/local/opt/ruby/lib/libruby.2.3.0.dylib
  Referenced from: /usr/local/bin/vim
  Reason: image not found
Trace/BPT trap: 5
```
## Background

IIRC,we uninstalled homebrew ruby b/c it caused gotchas with detecting
the correct ruby version. I _think_ that’s moot now b/c our rbenv
initialization is better.

👋 @ashleywchu 
