### PR TITLE
Allow setting DANGER_ZONE to not check OS version

### DIFF
--- a/mac
+++ b/mac
@@ -54,12 +54,14 @@ exit_message() {
 trap exit_message EXIT
 
 ## Check OS X >= 10.10
-
-if [[ $(sw_vers -productVersion) != 10.1[0-1].* ]]; then
-  print_error "Unsupported OS X version. Please use OS X Yosemite or El Capitan."
-  exit 1
+if ! [ -n "$DANGER_ZONE" ]; then
+  print_warning "Skipping check of macOS/OS X version. 😎  DANGER ZONE"
+else
+  if [[ $(sw_vers -productVersion) != 10.1[0-1].* ]]; then
+    print_error "Unsupported OS X version. Please use OS X Yosemite or El Capitan."
+    exit 1
+  fi
 fi
-
 ##
 # Detect if you're in a tmux session
 if [ -n "$TMUX" ]; then

--- a/mac
+++ b/mac
@@ -54,7 +54,7 @@ exit_message() {
 trap exit_message EXIT
 
 ## Check OS X >= 10.10
-if ! [ -n "$DANGER_ZONE" ]; then
+if [ -n "$DANGER_ZONE" ]; then
   print_warning "Skipping check of macOS/OS X version. 😎  DANGER ZONE"
 else
   if [[ $(sw_vers -productVersion) != 10.1[0-1].* ]]; then


### PR DESCRIPTION
## What

Let’s the user pass `DANGER_ZONE=1` to the script to not check for the OS version.
## Why

In most cases we do want to check that the user is running a supported version of the operating system. However sometimes a user needs to run an unsupported OS.

Fixes #28 
cc @ktheory
