### PR TITLE
Detect & fix homebrew update bug from Aug 10-11.

### DIFF
--- a/mac
+++ b/mac
@@ -114,6 +114,16 @@ if ! command -v brew >/dev/null; then
   print_done
 fi
 
+# Workaround broken brew update from Aug 11
+# https://github.com/Homebrew/homebrew-core#update-bug
+# 1471233600 = Aug 15, 2016, after the issue.
+brew_last_change=$(git --git-dir=/usr/local/.git log -n 1 --pretty=%at)
+if [ "$brew_last_change" -le "1471233600" ]; then
+  print_status "Fixing brew update bug"
+  (cd "$(brew --repo)"; git fetch; git reset --hard origin/master; brew update) > /dev/null
+  print_done
+fi
+
 print_status "Checking Homebrew formulae"
 brew bundle --file=- > /dev/null <<EOF
 tap "homebrew/services" # For 'brew service'


### PR DESCRIPTION
This checks if homebrew has not been updated since Aug 15 (a few days
after the bug). If so, it forces and update to [fix the bug](https://github.com/Homebrew/homebrew-core#update-bug).

I tested this by resetting my homebrew to Aug 11:

```
cd /usr/local; git reset --hard b7dc6ce
```

…then running this script.

Tip o' the hat to @christopherwright & @blinsay for reporting.
