### PR TITLE
Add parallel homebrew dep

### DIFF
--- a/mac
+++ b/mac
@@ -134,6 +134,7 @@ brew "openssl"
 brew "rbenv"
 brew "ruby-build"
 brew "n"
+brew "parallel"
 cask "java"
 EOF
 


### PR DESCRIPTION
This lets us use GNU `parallel` on macOS.

:wave: @talaris 
