### PR TITLE
Better show output of failed commands

### DIFF
--- a/mac
+++ b/mac
@@ -69,13 +69,16 @@ EOF
 # shellcheck disable=SC1090
 source ~/.ksr_functions.sh
 
+tmp_output=$(mktemp)
 exit_message() {
   ret=$?
  if [ $ret -ne 0 ]; then
+   if [ -e "$tmp_output" ]; then cat "$tmp_output"; fi
    printf "\n\n"
    print_error "Setup failed. 💔  "
    print_error "Try running this command again, or paste this output in #dev-environments Slack channel"
  fi
+ rm -f "$tmp_output"
  exit $ret
 }
 
@@ -106,7 +109,7 @@ fi
 
 # XCode command-line tools
 # From http://stackoverflow.com/a/15371967
-while ! pkgutil --pkg-info=com.apple.pkg.CLTools_Executables > /dev/null 2>&1; do
+while ! pkgutil --pkg-info=com.apple.pkg.CLTools_Executables > "$tmp_output" 2>&1; do
 
   if [ -z "$xcode_cli_installing" ]
   then
@@ -142,6 +145,10 @@ if [ -n "$SKIP_DOCKER" ]; then
   # Add flag for folks who wish to opt out of pow.
   print_warning "Skipping Docker setup because 'SKIP_DOCKER' is set. YMMV."
 else
+
+  # Unset old boot2docker config
+  unset DOCKER_CERT_PATH DOCKER_HOST DOCKER_IP DOCKER_TLS_VERIFY
+
   if ! [ -d "/Applications/Docker.app" ]
   then
 
@@ -158,7 +165,7 @@ else
   fi
 
   print_status "Ensuring Docker is running"
-  if ! /usr/local/bin/docker ps > /dev/null 2>&1
+  if ! /usr/local/bin/docker ps > "$tmp_output" 2>&1
   then
     open /Applications/Docker.app
   fi
@@ -184,7 +191,7 @@ if [ "$brew_last_change" -le "1471233600" ]; then
 fi
 
 print_status "Checking Homebrew formulae"
-brew bundle --file=- > /dev/null <<EOF
+brew bundle --file=- > "$tmp_output" <<EOF
 tap "homebrew/services" # For 'brew service'
 tap "caskroom/cask" # For java
 


### PR DESCRIPTION
This makes it easier to debug failed commands.

Also, unset boot2docker env vars; which speeds up `docker ps`.