### PR TITLE
OS X Sierra fix for permissions issue on /usr/local

### DIFF
--- a/mac
+++ b/mac
@@ -193,8 +193,7 @@ fi
 # Fix permission issue on /usr/local on OS 10.12
 if [ ! -w /usr/local ]; then
   print_status "Fixing /usr/local permissions issue"
-  sudo chgrp -R staff /usr/local
-  sudo chmod g+w /usr/local
+  sudo chown -R $(whoami) /usr/local
   print_done
 fi
 

--- a/mac
+++ b/mac
@@ -190,6 +190,14 @@ if [ "$brew_last_change" -le "1471233600" ]; then
   print_done
 fi
 
+# Fix permission issue on /usr/local on OS 10.12
+if [ ! -w /usr/local ]; then
+  print_status "Fixing /usr/local permissions issue"
+  sudo chgrp -R staff /usr/local
+  sudo chmod g+w /usr/local
+  print_done
+fi
+
 print_status "Checking Homebrew formulae"
 brew bundle --file=- > "$tmp_output" <<EOF
 tap "homebrew/services" # For 'brew service'

--- a/mac
+++ b/mac
@@ -193,7 +193,7 @@ fi
 # Fix permission issue on /usr/local on OS 10.12
 if [ ! -w /usr/local ]; then
   print_status "Fixing /usr/local permissions issue"
-  sudo chown -R $(whoami) /usr/local
+  sudo chown -R "$(whoami)" /usr/local
   print_done
 fi
 


### PR DESCRIPTION
`bin/dev` had been failing on new OS 10.12 Sierra installs due to permissions on `/usr/local`. This checks and fixes by `chgrp staff` and adding `g+w` which seemed like the least drastic fix.

There was some chatter about this in Dec and Jan in [Slack](https://kickstarter.slack.com/archives/dev-environments/p1482158592000270) so just adding the fix for everyone.

Here's what the error message looks like:
```
[13:50:49] Configuring node v6.9.1 ... mkdir: /usr/local/n/versions/node: Permission denied
mkdir: /usr/local/n/versions/io: Permission denied

     install : node-v6.9.1
       mkdir : /usr/local/n/versions/node/6.9.1
mkdir: /usr/local/n/versions/node/6.9.1: Permission denied

  Error: sudo required

Kickstarter Setup failed. 💔  
```