### PR TITLE
Add better handling in scenario where Homebrew can't uninstall package.

### DIFF
--- a/mac
+++ b/mac
@@ -218,7 +218,7 @@ print_done
 function uninstall_homebrew_package {
   if brew ls --versions "$1" > /dev/null; then
     print_status "Uninstalling Homebrew package ‘$1’"
-    brew uninstall --force "$1" > /dev/null
+    brew uninstall --force "$1" > /dev/null 2> "$tmp_output"
     print_done
   fi
 }

--- a/mac
+++ b/mac
@@ -213,13 +213,20 @@ brew "parallel"
 brew "rbenv"
 brew "ruby-build"
 EOF
+print_done
+
+function uninstall_homebrew_package {
+  if brew ls --versions "$1" > /dev/null; then
+    print_status "Uninstalling Homebrew package ‘$1’"
+    brew uninstall --force "$1" > /dev/null
+    print_done
+  fi
+}
 
 # Uninstall problematic brew packages
-brew uninstall --force brew-cask 2> /dev/null
-brew uninstall --force node 2> /dev/null
-brew uninstall --force node4-lts 2> /dev/null
-
-print_done
+uninstall_homebrew_package brew-cask
+uninstall_homebrew_package node
+uninstall_homebrew_package node4-tls
 
 ##
 # Configure rbenv


### PR DESCRIPTION
Yesterday I installed the 'yarn' package via Homebrew. It has a
dependency on the 'node' package. I ran `bin/dev` today and it failed
without an error message. This is because the laptop script attempts to
uninstall Homebrew's 'node' package, but it could not because the 'yarn'
package has a dependency on it.

Prior to this commit, if Homebrew encounters an error, we redirect them
to `/dev/null`, which is why I didn't have any idea what the issue was.

With the changes in this commit, I added more logging when we uninstall
a Homebrew package and only redirect stdout (not stderr) to `/dev/null`.