### PR TITLE
Ensure we use homebrew readline to avoid Editline unicode probs.

### DIFF
--- a/mac
+++ b/mac
@@ -41,9 +41,8 @@ check_ruby_version() {
   print_status "Checking ruby version"
   rbenv_path=$(which rbenv)
   if ! $rbenv_path exec ruby -v > /dev/null 2>&1; then
-    # Use the system readline so ruby doesn't break when the homebrew
-    # readline version changes
-    export RUBY_CONFIGURE_OPTS=--with-readline-dir="/usr/lib"
+    # ensure we use homebrew's readline to avoid OSX's Editline version of readline
+    export RUBY_CONFIGURE_OPTS=--with-readline-dir=`brew --prefix readline`
     $rbenv_path install "$(cat .ruby-version)"
   fi
   print_done


### PR DESCRIPTION
This change uses homebrew-installed readline when building Ruby. Currently we're pegged to the OSX system Editline library, but that seems to have issues when pasting unicode characters in. For example here I'm pasting some utf8 from my clipboard into the Rails console (pry):

``` ruby
> Readline::VERSION
=> "EditLine wrapper"
[21] pry(main)> "-"+FFE3-\U+FFE3"
=> "-"
```

When I rebuild Ruby linked to the Homebrew library, I can successfully paste unicode. I think this will be more important/useful for debugging after we launch in Japan.

 As discussed [here](https://github.com/kickstarter/laptop/pull/39#issuecomment-278695517), there are issues when upgrading the Homebrew readline, but I think that's easier to fix on a case-by-case basis than dealing with Editline issues.