### PR TITLE
Remove homebrew auto-updater LaunchAgent

### DIFF
--- a/mac
+++ b/mac
@@ -236,37 +236,6 @@ print_status "Initializing rbenv"
 eval "$(rbenv init -)"
 print_done
 
-print_status "Checking Homebrew updater"
-mkdir -p ~/Library/LaunchAgents
-##
-# Automatically run `brew update` every 2 hours
-# This saves ~20 seconds on subsequent runs b/c we don't have to wait for `brew update`
-cat > ~/Library/LaunchAgents/com.kickstarter.homebrew-updater.plist <<- EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>com.kickstarter.homebrew-updater</string>
-    <key>ProgramArguments</key>
-    <array>
-    <string>/usr/local/bin/brew</string>
-    <string>update</string>
-    </array>
-
-    <key>RunAtLoad</key>
-    <true/>
-
-    <key>StartInterval</key>
-    <integer>7200</integer>
-  </dict>
-</plist>
-EOF
-
-launchctl unload ~/Library/LaunchAgents/com.kickstarter.homebrew-updater.plist 2> /dev/null
-launchctl load   ~/Library/LaunchAgents/com.kickstarter.homebrew-updater.plist
-print_done
-
 ##
 # source ~/.ksr.rc from shell's rc file
 cat > ~/.ksr.rc <<-"EOF"


### PR DESCRIPTION
It’s obsolete.

Fixes #38.

:wave: @talaris 

NB: this PR only stops the task from being provisioned by the laptop script. I'll make another PR to ensure it's cleaned up.