### PR TITLE
Brew install rbenv-vars

### DIFF
--- a/mac
+++ b/mac
@@ -210,6 +210,7 @@ brew "n"
 brew "openssl"
 brew "parallel"
 brew "rbenv"
+brew "rbenv-vars"
 brew "ruby-build"
 EOF
 print_done


### PR DESCRIPTION
This is a more consistent way to store environment variables than .powenv, because it's initialized whenever rbenv initializes ruby.