### PR TITLE
Use kickstarter fork instead of ktheory to fix launchctl problem

### DIFF
--- a/mac
+++ b/mac
@@ -312,8 +312,7 @@ else
   # Increase pow's default idle timeout to 1hr
   echo "export POW_TIMEOUT=3600" > ~/.powconfig
   print_status "Checking Pow web server"
-  response=$(curl --fail -sH host:pow "127.0.0.1/status.json" | jq .version)
-  if  [ response != '0.6.0' ]; then
+  if  ! curl --fail -sH host:pow "127.0.0.1/status.json"  > /dev/null; then
     # Use custom install script until https://github.com/basecamp/pow/pull/505 is released
     # curl -s get.pow.cx | sh
     curl -s https://raw.githubusercontent.com/kickstarter/pow/fix-launchctl-bootstrap/install.sh | sh

--- a/mac
+++ b/mac
@@ -312,7 +312,8 @@ else
   # Increase pow's default idle timeout to 1hr
   echo "export POW_TIMEOUT=3600" > ~/.powconfig
   print_status "Checking Pow web server"
-  if  ! curl --fail -sH host:pow "127.0.0.1/status.json"  > /dev/null; then
+  response=$(curl --fail -sH host:pow "127.0.0.1/status.json" | jq .version)
+  if  [ response != '0.6.0' ]; then
     # Use custom install script until https://github.com/basecamp/pow/pull/505 is released
     # curl -s get.pow.cx | sh
     curl -s https://raw.githubusercontent.com/kickstarter/pow/fix-launchctl-bootstrap/install.sh | sh

--- a/mac
+++ b/mac
@@ -315,7 +315,7 @@ else
   if  ! curl --fail -sH host:pow "127.0.0.1/status.json"  > /dev/null; then
     # Use custom install script until https://github.com/basecamp/pow/pull/505 is released
     # curl -s get.pow.cx | sh
-    curl -s https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/install.sh | sh
+    curl -s https://raw.githubusercontent.com/kickstarter/pow/fix-launchctl-bootstrap/install.sh | sh
   fi
   print_done
 fi


### PR DESCRIPTION
Proposal to switch to using a `kickstarter` fork of `pow` with the most recent changes pertaining to changing the default domain. Here's the changes on that branch: https://github.com/kickstarter/pow/tree/fix-launchctl-bootstrap. Just the most recent release and our launchctl change. 