### PR TITLE
Automatically create /usr/bin/n after installing 'n' package.

### DIFF
--- a/mac
+++ b/mac
@@ -193,7 +193,7 @@ fi
 # directory ourselves.
 if [ ! -d /usr/local/n ]; then
   sudo mkdir /usr/local/n
-  sudo chown $USER:admin /usr/local/n
+  sudo chown "$USER:admin" /usr/local/n
 fi
 
 print_status "Checking Homebrew formulae"

--- a/mac
+++ b/mac
@@ -187,6 +187,15 @@ if sw_vers -productVersion | grep -q "^10.1[0-3]" && [ ! -w "$(brew --prefix)/Ce
   print_done
 fi
 
+# At the time of writing, the ‘n’ (node.js version manager) package doesn't
+# automatically create the `/usr/local/n` directory automatically, so an error
+# occurs when `n` is tried for the first time. So we'll manually create the
+# directory ourselves.
+if [ ! -d /usr/local/n ]; then
+  sudo mkdir /usr/local/n
+  sudo chown $USER:admin /usr/local/n
+fi
+
 print_status "Checking Homebrew formulae"
 brew bundle --file=- > "$tmp_output" <<EOF
 tap "homebrew/services" # For 'brew service'


### PR DESCRIPTION
When running `/bin/dev` for the first time we install the 'n' package
which manages node.js versions. When 'n' is first run, it expects the
`/usr/local/n` directory to be created. This is currently not the case
so the user hits an error and has to manually create it themselves.

This updates our laptop script to automatically create this directory if
it's not already created.

Relevant Slack convo from tonight:

* https://kickstarter.slack.com/archives/C0PNB94BU/p1515537550000149