### PR TITLE
Always run `gem install` in `check_bundler_dependencies`

### DIFF
--- a/mac
+++ b/mac
@@ -52,11 +52,7 @@ check_bundler_dependencies() {
   print_status "Checking bundler dependencies"
   # Install latest used version of bundler
   BUNDLER_VERSION=$(tail -n 1 Gemfile.lock | tr -d ' ')
-  if ! bundle version 2>/dev/null |grep -Fq "$BUNDLER_VERSION"
-  then
-    gem install -q bundler -v "=$BUNDLER_VERSION" --no-ri --no-rdoc
-  fi
-
+  gem install -q bundler -v "=$BUNDLER_VERSION" --no-ri --no-rdoc
   if ! bundle check >/dev/null
   then
     bundle install


### PR DESCRIPTION
This avoids a bug I ran into when running bin/dev for the first time.

Namely: We require `bundler` to be installed via rbenv, but I had bundler installed through my system ruby, so subsequent rake tasks would fail, since the rbenv space never actually had bundler installed. 

Since `gem install bundler` is idempotent and fast, let's just do the simple thing and run it on every invocation of `check_bundler_dependencies`.