### PR TITLE
Allow choosing between pow and puma-dev

### DIFF
--- a/mac
+++ b/mac
@@ -185,7 +185,7 @@ if sw_vers -productVersion | grep -q "^10.1[0-3]" && [ ! -w "$(brew --prefix)/Ce
   print_done
 fi
 
-# At the time of writing, the ‘n’ (node.js version manager) package doesn't
+# At the time of writing (2018-01-09), the ‘n’ (node.js version manager) package doesn't
 # automatically create the `/usr/local/n` directory automatically, so an error
 # occurs when `n` is tried for the first time. So we'll manually create the
 # directory ourselves.
@@ -318,7 +318,6 @@ function puma_certificate_installed {
   security verify-cert -c "${puma_certificate_file}" > /dev/null 2>&1
 }
 
-
 # Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
 function deconfigure_puma_dev {
   puma-dev -uninstall -d test
@@ -373,7 +372,10 @@ fi
 # See https://github.com/basecamp/pow/wiki/Troubleshooting#rbenv
 if [ -n "$SKIP_POW" ]; then
   # Add flag for folks who wish to opt out of pow.
-  print_warning "Skipping Pow setup because 'SKIP_POW' is set. YMMV."
+
+  if [[ "$DEVELOPMENT_SERVER" = "pow" ]]; then
+     print_warning "Skipping Pow setup because 'SKIP_POW' is set. YMMV."
+  fi
 else
 
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
@@ -396,7 +398,9 @@ fi
 ##
 # Install puma-dev development server
 if [ -n "$SKIP_PUMA_DEV" ]; then
-  print_warning "Skipping puma-dev setup because 'SKIP_PUMA_DEV' is set."
+  if [[ "$DEVELOPMENT_SERVER" = "puma-dev" ]]; then
+    print_warning "Skipping puma-dev setup because 'SKIP_PUMA_DEV' is set."
+  fi
 else
   # ------------ TEMPORARILY UNINSTALL POW ------------------------
   uninstall_pow

--- a/mac
+++ b/mac
@@ -6,6 +6,8 @@
 
 set -e
 
+SKIP_POW=true
+
 cat > ~/.ksr_functions.sh <<-"EOF"
 # Helpful functions for from the kickstarter
 # laptop script
@@ -198,6 +200,7 @@ print_status "Checking Homebrew formulae"
 brew bundle --file=- > "$tmp_output" <<EOF
 tap "homebrew/services" # For 'brew service'
 tap "caskroom/cask" # For java
+tap "puma/puma" # For puma-dev
 
 cask "java"
 
@@ -207,6 +210,7 @@ brew "jq"
 brew "n"
 brew "openssl"
 brew "parallel"
+brew "puma-dev"
 brew "rbenv"
 brew "ruby-build"
 EOF
@@ -325,6 +329,30 @@ else
     # curl -s get.pow.cx | sh
     curl -s https://raw.githubusercontent.com/kickstarter/pow/fix-launchctl-bootstrap/install.sh | sh
   fi
+  print_done
+fi
+
+##
+# Install puma-dev development server
+PUMA_DEV_DOMAIN=test
+if [ -n "$SKIP_PUMA_DEV" ]; then
+  print_warning "Skipping Puma-Dev setup because 'SKIP_PUMA_DEV' is set."
+else
+  print_status "Checking Puma-Dev server"
+  if  ! curl --fail -sH "Host: puma-dev" localhost/status  > /dev/null; then
+    echo "Setting up PUMA" # puma-dev is installed by homebrew
+    sudo puma-dev -setup -d "$PUMA_DEV_DOMAIN"
+    puma-dev -install -d "$PUMA_DEV_DOMAIN"
+#    puma-dev -uninstall -d "$PUMA_DEV_DOMAIN"
+  fi
+
+  if ! security verify-cert -c ~/Library/Application\ Support/io.puma.dev/cert.pem; then
+    echo "Installing Certificate"
+    # Return value is pre-quoted with extra space, xargs clears it by echoing
+    login_keychain=$(security login-keychain|xargs)
+    security add-trusted-cert -k ${login_keychain} ~/Library/Application\ Support/io.puma.dev/cert.pem
+  fi
+
   print_done
 fi
 

--- a/mac
+++ b/mac
@@ -342,7 +342,12 @@ else
   # ------------ TEMPORARILY ALWAYS UNINSTALL POW ------------------------
   print_warning "TEMPORARILY ALWAYS UNINSTALL POW"
   # Uninstall pow
-  curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
+  # If pow is installed, uninstall
+  POW_CURRENT_PATH="$HOME/Library/Application Support/Pow/Current"
+
+  if [ -d "$POW_CURRENT_PATH" ] && [ ! -a "$POWD_PLIST_PATH" ] && [ ! -a "$FIREWALL_PLIST_PATH" ]; then
+    curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
+  fi
   # ------------ TEMPORARILY ALWAYS UNINSTALL POW ------------------------
 
   print_status "Checking Puma-Dev server"

--- a/mac
+++ b/mac
@@ -338,6 +338,13 @@ PUMA_DEV_DOMAIN=test
 if [ -n "$SKIP_PUMA_DEV" ]; then
   print_warning "Skipping Puma-Dev setup because 'SKIP_PUMA_DEV' is set."
 else
+
+  # ------------ TEMPORARILY ALWAYS UNINSTALL POW ------------------------
+  print_warning "TEMPORARILY ALWAYS UNINSTALL POW"
+  # Uninstall pow
+  curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
+  # ------------ TEMPORARILY ALWAYS UNINSTALL POW ------------------------
+
   print_status "Checking Puma-Dev server"
   if  ! curl --fail -sH "Host: puma-dev" localhost/status  > /dev/null; then
     echo "Setting up PUMA" # puma-dev is installed by homebrew

--- a/mac
+++ b/mac
@@ -312,6 +312,44 @@ fi
 # Use osxkeychain for git https passwords
 git config --global credential.helper osxkeychain
 
+
+## Puma-Dev Management
+puma_certificate_file="${HOME}/Library/Application Support/io.puma.dev/cert.pem"
+
+# Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
+function deconfigure_puma_dev {
+  puma-dev -uninstall -d test
+  security remove-trusted-cert "${puma_certificate_file}"
+}
+
+# Configure puma-dev, assumes that the puma-dev gem is installed
+function configure_puma_dev {
+  if  ! curl --fail -sH "Host: puma-dev" localhost/status > /dev/null; then
+    echo "Configuring puma-dev" # puma-dev is installed by homebrew
+    sudo puma-dev -setup -d test
+    puma-dev -install -d test
+  fi
+
+  if ! security verify-cert -c "${puma_certificate_file}" > /dev/null; then
+    echo "Installing Certificate"
+    # Return value is pre-quoted with extra space, xargs clears it by echoing
+    login_keychain=$(security login-keychain|xargs)
+    # shellcheck disable=SC2086
+    security add-trusted-cert -k ${login_keychain} "${puma_certificate_file}"
+  fi
+}
+
+# Uninstall pow, if installed
+function uninstall_pow {
+  POW_CURRENT_PATH="${HOME}/Library/Application Support/Pow/Current"
+
+  if [ -d "$POW_CURRENT_PATH" ] && [ ! -a "$POWD_PLIST_PATH" ] && [ ! -a "$FIREWALL_PLIST_PATH" ]; then
+    print_warning "Uninstalling POW"
+    curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
+  fi
+}
+
+
 ##
 # Install Pow web server
 # NB: we must install pow after the shell is configured with rbenv.
@@ -322,9 +360,9 @@ if [ -n "$SKIP_POW" ]; then
 else
 
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
-  # If you're using pow, you're not using puma-dev ?
+  # If you're using pow, you're not using puma-dev
   export SKIP_PUMA_DEV=true
-  puma-dev -uninstall -d test
+  deconfigure_puma_dev
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
 
 
@@ -343,35 +381,14 @@ fi
 ##
 # Install puma-dev development server
 if [ -n "$SKIP_PUMA_DEV" ]; then
-  print_warning "Skipping Puma-Dev setup because 'SKIP_PUMA_DEV' is set."
+  print_warning "Skipping puma-dev setup because 'SKIP_PUMA_DEV' is set."
 else
-
   # ------------ TEMPORARILY UNINSTALL POW ------------------------
-  print_warning "TEMPORARILY UNINSTALL POW"
-  # Uninstall pow
-  # If pow is installed, uninstall
-  POW_CURRENT_PATH="$HOME/Library/Application Support/Pow/Current"
-
-  if [ -d "$POW_CURRENT_PATH" ] && [ ! -a "$POWD_PLIST_PATH" ] && [ ! -a "$FIREWALL_PLIST_PATH" ]; then
-    curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
-  fi
+  uninstall_pow
   # ------------ TEMPORARILY UNINSTALL POW ------------------------
 
-  print_status "Checking Puma-Dev server"
-  if  ! curl --fail -sH "Host: puma-dev" localhost/status  > /dev/null; then
-    echo "Setting up PUMA" # puma-dev is installed by homebrew
-    sudo puma-dev -setup -d test
-    puma-dev -install -d test
-#    puma-dev -uninstall -d test
-  fi
-
-  if ! security verify-cert -c ~/Library/Application\ Support/io.puma.dev/cert.pem; then
-    echo "Installing Certificate"
-    # Return value is pre-quoted with extra space, xargs clears it by echoing
-    login_keychain=$(security login-keychain|xargs)
-    security add-trusted-cert -k ${login_keychain} ~/Library/Application\ Support/io.puma.dev/cert.pem
-  fi
-
+  print_status "Checking puma-dev server"
+  configure_puma_dev
   print_done
 fi
 

--- a/mac
+++ b/mac
@@ -6,8 +6,6 @@
 
 set -e
 
-SKIP_POW=true
-
 cat > ~/.ksr_functions.sh <<-"EOF"
 # Helpful functions for from the kickstarter
 # laptop script

--- a/mac
+++ b/mac
@@ -314,10 +314,17 @@ git config --global credential.helper osxkeychain
 ## Puma-Dev Management
 puma_certificate_file="${HOME}/Library/Application Support/io.puma.dev/cert.pem"
 
+function puma_certificate_installed {
+  security verify-cert -c "${puma_certificate_file}" > /dev/null 2>&1
+}
+
+
 # Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
 function deconfigure_puma_dev {
   puma-dev -uninstall -d test
-  security remove-trusted-cert "${puma_certificate_file}"
+  if puma_certificate_installed; then
+    security remove-trusted-cert "${puma_certificate_file}"
+  fi
 }
 
 # Configure puma-dev, assumes that the puma-dev gem is installed
@@ -328,8 +335,8 @@ function configure_puma_dev {
     puma-dev -install -d test
   fi
 
-  if ! security verify-cert -c "${puma_certificate_file}" > /dev/null; then
-    echo "Installing Certificate"
+  if ! puma_certificate_installed; then
+    echo "Installing Certificate (password required)"
     # Return value is pre-quoted with extra space, xargs clears it by echoing
     login_keychain=$(security login-keychain|xargs)
     # shellcheck disable=SC2086
@@ -347,6 +354,18 @@ function uninstall_pow {
   fi
 }
 
+# Temporarily allow switching between pow and puma-dev with this flag.
+export DEVELOPMENT_SERVER=${DEVELOPMENT_SERVER:=pow}
+print_status "Using development server ${DEVELOPMENT_SERVER} (set with DEVELOPMENT_SERVER=)"
+print_done
+
+if [[ "$DEVELOPMENT_SERVER" != "puma-dev" ]]; then
+  export SKIP_PUMA_DEV=1
+fi
+
+if [[ "$DEVELOPMENT_SERVER" != "pow" ]]; then
+  export SKIP_POW=1
+fi
 
 ##
 # Install Pow web server
@@ -358,8 +377,6 @@ if [ -n "$SKIP_POW" ]; then
 else
 
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
-  # If you're using pow, you're not using puma-dev
-  export SKIP_PUMA_DEV=true
   deconfigure_puma_dev
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
 

--- a/mac
+++ b/mac
@@ -308,32 +308,35 @@ if ! grep -Fqs "$cmd" "$profile"; then
 fi
 
 # Use osxkeychain for git https passwords
+print_status "Configuring osxkeychain for git passwords"
 git config --global credential.helper osxkeychain
-
+print_done
 
 ## Puma-Dev Management
 puma_certificate_file="${HOME}/Library/Application Support/io.puma.dev/cert.pem"
 
 function puma_certificate_installed {
-  security verify-cert -c "${puma_certificate_file}" > /dev/null 2>&1
+  security verify-cert -c "${puma_certificate_file}" >> "$tmp_output" 2>&1
 }
 
 # Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
 function deconfigure_puma_dev {
-  if command -v puma-dev; then
-    puma-dev -stop || true
-    puma-dev -uninstall -d test
+  if command -v puma-dev >> "$tmp_output"; then
+    # Only attempt to disable .test DNS resolution if puma was actually running.
+    if puma-dev -stop >> "$tmp_output" 2>&1; then
+      puma-dev -uninstall -d test
+    fi
   fi
 
   if puma_certificate_installed; then
+    print_warning "You may need to remove HSTS settings for Chrome - chrome://net-internals/#hsts"
     security remove-trusted-cert "${puma_certificate_file}"
   fi
-  echo "You may need to remove HSTS settings for chrome://net-internals/#hsts"
 }
 
 # Configure puma-dev, assumes that the puma-dev gem is installed
 function configure_puma_dev {
-  if  ! curl --fail -sH "Host: puma-dev" localhost/status > /dev/null; then
+  if ! curl --fail -sH "Host: puma-dev" localhost/status >> "$tmp_output"; then
     echo "Configuring puma-dev" # puma-dev is installed by homebrew
     sudo puma-dev -setup -d test
     puma-dev -install -d test
@@ -346,6 +349,8 @@ function configure_puma_dev {
     # shellcheck disable=SC2086
     security add-trusted-cert -k ${login_keychain} "${puma_certificate_file}"
   fi
+
+  [[ `curl --silent http://test` == 'unknown app' ]]
 }
 
 # Uninstall pow, if installed
@@ -358,9 +363,10 @@ function uninstall_pow {
   fi
 }
 
+# ----------- DEVELOPMENT_SERVER -----------
 # Temporarily allow switching between pow and puma-dev with this flag.
 export DEVELOPMENT_SERVER=${DEVELOPMENT_SERVER:=pow}
-print_status "Using development server ${DEVELOPMENT_SERVER} (set with DEVELOPMENT_SERVER=)"
+print_status "Using DEVELOPMENT_SERVER=$(tput bold)$(tput setaf 7)${DEVELOPMENT_SERVER}$(tput sgr0)"
 print_done
 
 if [[ "$DEVELOPMENT_SERVER" != "puma-dev" ]]; then
@@ -370,6 +376,7 @@ fi
 if [[ "$DEVELOPMENT_SERVER" != "pow" ]]; then
   export SKIP_POW=1
 fi
+# ----------- DEVELOPMENT_SERVER -----------
 
 ##
 # Install Pow web server
@@ -384,7 +391,9 @@ if [ -n "$SKIP_POW" ]; then
 else
 
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
+  print_status "Disabling Puma-dev"
   deconfigure_puma_dev
+  print_done
   # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
 
 
@@ -398,8 +407,9 @@ else
     pow_install_needed=true
   fi
 
+  # Will pow resolve for .test domains?
   # Puma-dev will 500 error on http://test, but Pow will succeed
-  if ! curl --fail --silent -I  http://test > /dev/null 2>&1; then
+  if ! curl --fail --silent -I http://test > /dev/null 2>&1; then
     pow_install_needed=true
   fi
 
@@ -424,6 +434,7 @@ else
   # ------------ TEMPORARILY UNINSTALL POW ------------------------
 
   print_status "Checking puma-dev server"
+  echo > "$tmp_output"
   configure_puma_dev
   print_done
 fi

--- a/mac
+++ b/mac
@@ -320,6 +320,14 @@ if [ -n "$SKIP_POW" ]; then
   # Add flag for folks who wish to opt out of pow.
   print_warning "Skipping Pow setup because 'SKIP_POW' is set. YMMV."
 else
+
+  # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
+  # If you're using pow, you're not using puma-dev ?
+  export SKIP_PUMA_DEV=true
+  puma-dev -uninstall -d test
+  # ------------ TEMPORARILY UNINSTALL PUMA ------------------------
+
+
   # Increase pow's default idle timeout to 1hr
   echo "export POW_TIMEOUT=3600" > ~/.powconfig
   echo "export POW_DOMAINS=test" >> ~/.powconfig
@@ -334,13 +342,12 @@ fi
 
 ##
 # Install puma-dev development server
-PUMA_DEV_DOMAIN=test
 if [ -n "$SKIP_PUMA_DEV" ]; then
   print_warning "Skipping Puma-Dev setup because 'SKIP_PUMA_DEV' is set."
 else
 
-  # ------------ TEMPORARILY ALWAYS UNINSTALL POW ------------------------
-  print_warning "TEMPORARILY ALWAYS UNINSTALL POW"
+  # ------------ TEMPORARILY UNINSTALL POW ------------------------
+  print_warning "TEMPORARILY UNINSTALL POW"
   # Uninstall pow
   # If pow is installed, uninstall
   POW_CURRENT_PATH="$HOME/Library/Application Support/Pow/Current"
@@ -348,14 +355,14 @@ else
   if [ -d "$POW_CURRENT_PATH" ] && [ ! -a "$POWD_PLIST_PATH" ] && [ ! -a "$FIREWALL_PLIST_PATH" ]; then
     curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
   fi
-  # ------------ TEMPORARILY ALWAYS UNINSTALL POW ------------------------
+  # ------------ TEMPORARILY UNINSTALL POW ------------------------
 
   print_status "Checking Puma-Dev server"
   if  ! curl --fail -sH "Host: puma-dev" localhost/status  > /dev/null; then
     echo "Setting up PUMA" # puma-dev is installed by homebrew
-    sudo puma-dev -setup -d "$PUMA_DEV_DOMAIN"
-    puma-dev -install -d "$PUMA_DEV_DOMAIN"
-#    puma-dev -uninstall -d "$PUMA_DEV_DOMAIN"
+    sudo puma-dev -setup -d test
+    puma-dev -install -d test
+#    puma-dev -uninstall -d test
   fi
 
   if ! security verify-cert -c ~/Library/Application\ Support/io.puma.dev/cert.pem; then

--- a/mac
+++ b/mac
@@ -325,8 +325,11 @@ function can_resolve_test_domain {
 
 # Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
 function deconfigure_puma_dev {
-  puma-dev -stop
-  puma-dev -uninstall -d test
+  if command -v puma-dev; then
+    puma-dev -stop || true
+    puma-dev -uninstall -d test
+  fi
+
   if puma_certificate_installed; then
     security remove-trusted-cert "${puma_certificate_file}"
   fi

--- a/mac
+++ b/mac
@@ -373,7 +373,7 @@ fi
 if [ -n "$SKIP_POW" ]; then
   # Add flag for folks who wish to opt out of pow.
 
-  if [[ "$DEVELOPMENT_SERVER" = "pow" ]]; then
+  if [[ "$DEVELOPMENT_SERVER" == "pow" ]]; then
      print_warning "Skipping Pow setup because 'SKIP_POW' is set. YMMV."
   fi
 else
@@ -398,7 +398,7 @@ fi
 ##
 # Install puma-dev development server
 if [ -n "$SKIP_PUMA_DEV" ]; then
-  if [[ "$DEVELOPMENT_SERVER" = "puma-dev" ]]; then
+  if [[ "$DEVELOPMENT_SERVER" == "puma-dev" ]]; then
     print_warning "Skipping puma-dev setup because 'SKIP_PUMA_DEV' is set."
   fi
 else

--- a/mac
+++ b/mac
@@ -357,7 +357,7 @@ function configure_puma_dev {
 function uninstall_pow {
   POW_CURRENT_PATH="${HOME}/Library/Application Support/Pow/Current"
 
-  if [ -d "$POW_CURRENT_PATH" ] && [ ! -a "$POWD_PLIST_PATH" ] && [ ! -a "$FIREWALL_PLIST_PATH" ]; then
+  if [ -d "$POW_CURRENT_PATH" ]; then
     print_warning "Uninstalling POW"
     curl -Ls https://raw.githubusercontent.com/ktheory/pow/fix-launchctl-bootstrap/uninstall.sh | bash
   fi

--- a/mac
+++ b/mac
@@ -350,7 +350,7 @@ function configure_puma_dev {
     security add-trusted-cert -k ${login_keychain} "${puma_certificate_file}"
   fi
 
-  [[ `curl --silent http://test` == 'unknown app' ]]
+  [[ $(curl --silent http://test) == 'unknown app' ]]
 }
 
 # Uninstall pow, if installed

--- a/mac
+++ b/mac
@@ -318,12 +318,19 @@ function puma_certificate_installed {
   security verify-cert -c "${puma_certificate_file}" > /dev/null 2>&1
 }
 
+# Sets a non-zero return code if cannot get to `test`
+function can_resolve_test_domain {
+  curl --fail --silent -I  http://test  2>&1 > /dev/null
+}
+
 # Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
 function deconfigure_puma_dev {
+  puma-dev -stop
   puma-dev -uninstall -d test
   if puma_certificate_installed; then
     security remove-trusted-cert "${puma_certificate_file}"
   fi
+  echo "You may need to remove HSTS settings for chrome://net-internals/#hsts"
 }
 
 # Configure puma-dev, assumes that the puma-dev gem is installed
@@ -387,9 +394,20 @@ else
   echo "export POW_TIMEOUT=3600" > ~/.powconfig
   echo "export POW_DOMAINS=test" >> ~/.powconfig
   print_status "Checking Pow web server"
-  if  ! curl --fail -sH host:pow "127.0.0.1/status.json"  > /dev/null; then
+
+  pow_install_needed=""
+  if  ! curl --fail -sH host:pow "127.0.0.1/status.json" > /dev/null; then
+    pow_install_needed=true
+  fi
+
+  if ! can_resolve_test_domain; then
+    pow_install_needed=true
+  fi
+
+  if [ -n "$pow_install_needed" ]; then
     # Use custom install script until https://github.com/basecamp/pow/pull/505 is released
     # curl -s get.pow.cx | sh
+    echo "Installing Pow"
     curl -s https://raw.githubusercontent.com/kickstarter/pow/fix-launchctl-bootstrap/install.sh | sh
   fi
   print_done

--- a/mac
+++ b/mac
@@ -318,11 +318,6 @@ function puma_certificate_installed {
   security verify-cert -c "${puma_certificate_file}" > /dev/null 2>&1
 }
 
-# Sets a non-zero return code if cannot get to `test`
-function can_resolve_test_domain {
-  curl --fail --silent -I  http://test  2>&1 > /dev/null
-}
-
 # Remove the Puma-dev TLS root cert, disable puma-dev dns resolution for .test domains
 function deconfigure_puma_dev {
   if command -v puma-dev; then
@@ -403,7 +398,8 @@ else
     pow_install_needed=true
   fi
 
-  if ! can_resolve_test_domain; then
+  # Puma-dev will 500 error on http://test, but Pow will succeed
+  if ! curl --fail --silent -I  http://test > /dev/null 2>&1; then
     pow_install_needed=true
   fi
 


### PR DESCRIPTION
Adds a DEVELOPMENT_SERVER environment variable to switch between the chosen development server.

The default remains `pow` but people can opt-in to the new shiny that is puma-dev.

For more context see PR: https://github.com/kickstarter/kickstarter/pull/11605