### PR TITLE
curl check for unknownapp.test so script doesn't fail

### DIFF
--- a/mac
+++ b/mac
@@ -350,7 +350,7 @@ function configure_puma_dev {
     security add-trusted-cert -k ${login_keychain} "${puma_certificate_file}"
   fi
 
-  [[ $(curl --silent http://test) == 'unknown app' ]]
+  [[ $(curl --silent http://expectUnknownApp.test) == 'unknown app' ]]
 }
 
 # Uninstall pow, if installed


### PR DESCRIPTION
The script fails when checking `http://test` so it was updated to a more explicit unknown url in the test domain. 