### PR TITLE
Need to configure mysql2 to use homebrew ssl

### DIFF
--- a/mac
+++ b/mac
@@ -53,6 +53,7 @@ check_bundler_dependencies() {
   # Install latest used version of bundler
   BUNDLER_VERSION=$(tail -n 1 Gemfile.lock | tr -d ' ')
   gem install -q bundler -v "=$BUNDLER_VERSION" --no-ri --no-rdoc
+  bundle config --global build.mysql2 --with-opt-dir="$(brew --prefix openssl)"
   if ! bundle check >/dev/null
   then
     bundle install


### PR DESCRIPTION
# What
This is related to this [kickstarter PR](https://github.com/kickstarter/kickstarter/pull/13388) where we updated the mysql2 gem.

We need to configure bundler to use home-brew's openssl lib when installed mysql2 per [this issues](https://github.com/brianmario/mysql2/issues/795).

# Why

In some configurations users won't be able to install the `mysql2` gem on their Mac. I tested this fix with @jdibiccari and it seemed to work on her case.

# Who
@kickstarter/infrastructure + @jdibiccari 