### PR TITLE
Fixes newline issue for bash_profile

### DIFF
--- a/mac
+++ b/mac
@@ -265,7 +265,8 @@ case $(basename "$SHELL") in
 
     # Source bashrc from bash_profile
     if ! grep -Fqs 'source ~/.bashrc' "$HOME/.bash_profile"; then
-      echo 'source ~/.bashrc' >> "$HOME/.bash_profile"
+      echo ''
+      echo 'source ~/.bashrc # Provisioned by ksr laptop script' >> "$HOME/.bash_profile"
     fi
     ;;
   zsh )


### PR DESCRIPTION
Before, additions to `.bash_profile` from the script were made without adding a newline first.  If someone had a preexisting `.bash_profile`, these additions may have been added to a preexisting line, causing an error.

(also this is my first PR 🎉)