### PR TITLE
Add geckodriver to laptop script

### DIFF
--- a/mac
+++ b/mac
@@ -212,6 +212,10 @@ brew "parallel"
 brew "puma-dev"
 brew "rbenv"
 brew "ruby-build"
+
+# Used to run rspec feature tests
+brew "geckodriver" 
+
 EOF
 print_done
 


### PR DESCRIPTION
* When trying to run an rspec feature test locally both Pritika and
  I bumped into an issue where it was unable to find its webdriver.
  It recommends installing `geckodriver` and adding it to the path
  which can be confusing to the dev running it and slow them down.
  Luckily we already have a homebrew script and geckodriver exists
  in homebrew! So let's add it here and all of our machines will be
  able to run this from now on.