### PR TITLE
Remove deprecated `caskroom/cask`

### DIFF
--- a/mac
+++ b/mac
@@ -366,7 +366,7 @@ function uninstall_pow {
 
 # ----------- DEVELOPMENT_SERVER -----------
 # Temporarily allow switching between pow and puma-dev with this flag.
-export DEVELOPMENT_SERVER=${DEVELOPMENT_SERVER:=pow}
+export DEVELOPMENT_SERVER=${DEVELOPMENT_SERVER:=puma-dev}
 print_status "Using DEVELOPMENT_SERVER=$(tput bold)$(tput setaf 7)${DEVELOPMENT_SERVER}$(tput sgr0)"
 print_done
 

--- a/mac
+++ b/mac
@@ -198,7 +198,6 @@ fi
 print_status "Checking Homebrew formulae"
 brew bundle --file=- > "$tmp_output" <<EOF
 tap "homebrew/services" # For 'brew service'
-tap "caskroom/cask" # For java
 tap "puma/puma" # For puma-dev
 
 cask "java"


### PR DESCRIPTION
### Why
`caskroom/cask` has merged into Homebrew and we no longer need to explicitly tap it.
Newer computers were running into the error `Using homebrew/services
Error: caskroom/cask was moved. Tap homebrew/cask-cask instead.`

### CC
@kickstarter/infrastructure