### PR TITLE
Remove java from homebrew bundles

### DIFF
--- a/mac
+++ b/mac
@@ -200,8 +200,6 @@ brew bundle --file=- > "$tmp_output" <<EOF
 tap "homebrew/services" # For 'brew service'
 tap "puma/puma" # For puma-dev
 
-cask "java"
-
 brew "awscli"
 brew "git"
 brew "jq"


### PR DESCRIPTION
It is not used so remove it.

With the java line, when running `bin/dev`, it shows the following error:
```
Error: Cask 'java' is unavailable: No Cask with this name exists. Did you mean one of these?
eclipse-java
eclipse-javascript
netbeans-java-ee
netbeans-java-se
oracle-jdk-javadoc
```

@talaris told me that installing java for kickstarter isn't required anymore, so this patch removes the java related line.